### PR TITLE
Make org and repo optional parameters with defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ This GitHub Action waits for a specified workflow to complete before proceeding 
 | `max_wait_minutes`| Maximum time script will wait to workflow run to be found in minutes      | No       | 5       |
 | `interval`| Interval in seconds which will be used for GitHub API calls      | No       | 10       |
 | `timeout`| Maximum time script will wait to workflow run to be finished      | No       | 30       |
-| `org_name`   | Organization name where the repository is located   | Yes      |         |
-| `repo_name`     | Repository name to monitor for the workflow run     | Yes      |         |
+| `org_name`   | Organization name where the repository is located   | No       | Current organization        |
+| `repo_name`     | Repository name to monitor for the workflow run     | No       | Current repository        |
 | `ref`            | Branch reference to watch for the workflow run      | No       |         |
 
 ## How It Works

--- a/action.yml
+++ b/action.yml
@@ -27,10 +27,12 @@ inputs:
     default: '30'
   org_name:
     description: 'GitHub organization name'
-    required: true
+    required: false
+    default: ''
   repo_name:
     description: 'GitHub repository name'
-    required: true
+    required: false
+    default: ''
   ref:
     description: 'Branch reference (if empty, ref selected for trigger would be taken)'
     required: false
@@ -50,6 +52,6 @@ runs:
         MAX_WAIT_MINUTES: ${{ inputs.max_wait_minutes }}
         INTERVAL: ${{ inputs.interval }}
         TIMEOUT: ${{ inputs.timeout }}
-        ORG_NAME: ${{ inputs.org_name }}
-        REPO_NAME: ${{ inputs.repo_name }}
+        ORG_NAME: ${{ inputs.org_name || github.context.repo.owner }}
+        REPO_NAME: ${{ inputs.repo_name || github.context.repo.repo }}
         REF: ${{ inputs.ref || github.ref }}


### PR DESCRIPTION
The default location for workflows to await could be the same repo as the current workflow. If you're waiting for a workflow in the same repo, there's no need to deny devs the convenience of defaults.